### PR TITLE
Avoid using Moose::Autobox

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+    - Avoid using Moose::Autobox (kentnl, #1)
 
 0.142220  2014-08-10 16:48:00PDT-0700 America/Los_Angeles (TRIAL RELEASE)
     - Skip file names that are empty strings 

--- a/dist.ini
+++ b/dist.ini
@@ -5,5 +5,8 @@ license = Perl_5
 copyright_holder = Ryan C. Thompson
 copyright_year   = 2010
 
+; authordep Pod::Weaver::Section::Installation
+; authordep Pod::Weaver::Section::WarrantyDisclaimer
+
 [@Author::RTHOMPSON]
 synopsis_is_perl_code = false

--- a/lib/Dist/Zilla/Plugin/CopyFilesFromBuild.pm
+++ b/lib/Dist/Zilla/Plugin/CopyFilesFromBuild.pm
@@ -7,7 +7,6 @@ package Dist::Zilla::Plugin::CopyFilesFromBuild;
 
 use Moose;
 use MooseX::Has::Sugar;
-use Moose::Autobox;
 with qw/ Dist::Zilla::Role::AfterBuild /;
 
 use File::Copy ();
@@ -73,7 +72,7 @@ sub after_build {
 
 sub _prune_moved_files {
     my ($self, ) = @_;
-    for my $file ($self->zilla->files->flatten) {
+    for my $file (@{ $self->zilla->files }) {
         next unless any { $file->name eq $_ } @{$self->move};
 
         $self->log_debug([ 'pruning moved file %s', $file->name ]);


### PR DESCRIPTION
 This is mostly to remove undeeded dependencies which tend to be slightly
fragile and are currently impeding installation on blead.

See also: https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5 
