### PR TITLE
Files with a path are copied into root directory

### DIFF
--- a/lib/Dist/Zilla/Plugin/CopyFilesFromBuild.pm
+++ b/lib/Dist/Zilla/Plugin/CopyFilesFromBuild.pm
@@ -40,7 +40,7 @@ sub after_build {
         }
         my $src = path($build_root)->child( $path );
         if (-e $src) {
-            my $dest = path($self->zilla->root)->child( $src->basename );
+            my $dest = path($self->zilla->root)->child( $path );
             File::Copy::copy "$src", "$dest"
                 or $self->log_fatal("Unable to copy $src to $dest: $!");
             $self->log("Copied $src to $dest");


### PR DESCRIPTION
this is my dist.ini:

```
[CopyFilesFromBuild]
copy = Makefile.PL
copy = t/00.compile.t
```

The 00.compile.t is copied into the root directory, not into t/
